### PR TITLE
Replaced Game Boy Programming Manual broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here you can find everything to get started and master the development of unoffi
 - [#gbdev on EFnet](http://chat.efnet.org/?channels=gbdev) - IRC channel.
 
 ## Documentation
-- [Game Boy Programming Manual](http://www.romhacking.net/documents/544/) - **Official Game Boy** hardware manual by Nintendo. Pretty much everything in the console is covered and explained in this manual. This should be your first and main resource to start understanding what game boy is.
+- [Game Boy Programming Manual](http://www.chrisantonellis.com/files/gameboy/gb-programming-manual.pdf) - **Official Game Boy** programming & hardware manual by Nintendo. Pretty much everything in the console is covered and explained in this manual. This should be your first and main resource to start understanding what game boy is.
 - [The Cycle-Accurate Game Boy Docs](https://github.com/AntonioND/giibiiadvance/blob/master/docs/TCAGBD.pdf) - A precise documentation by AntonioND to make a cicle-accurate Game Boy emulator.
 - [Pan Docs](http://bgb.bircd.org/pandocs.htm) - The single most comprehensive technical reference to Game Boy that is available to the public.
 - [Everything You Always Wanted To Know About GAME BOY](http://www.emulatronia.com/doctec/consolas/gameboy/gameboy.txt) - but were afraid to ask


### PR DESCRIPTION
Replaced the "Game Boy Programming Manual" broken link http://www.romhacking.net/documents/544/ with an alternative version http://www.chrisantonellis.com/files/gameboy/gb-programming-manual.pdf 