### PR TITLE
Add "To C Or Not To C" writeup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A curated list of awesome Game Boy (Color) Development resources, tools, docs, r
 - [The Game Boy, a hardware autopsy](https://www.youtube.com/playlist?list=PLu3xpmdUP-GRDp8tknpXC_Y4RUQtMMqEu).
 - [The Ultimate Game Boy Talk](https://media.ccc.de/v/33c3-8029-the_ultimate_game_boy_talk).
 - [Emulation of Nintendo Game Boy](https://github.com/Baekalfen/PyBoy/blob/master/PyBoy.pdf) - Overview of the Game Boy hardware with the perspective of building an emulator.
+- [To C Or Not To C](https://gist.github.com/ISSOtm/4f4d335c3fd258ad0dfc7d4d615409fd) - Writeup offering a brief overview of the Game Boy's capabilities, discussing the pros and cons of the available development tools, and providing tips to write more efficient code.
 
 #### Disambiguation
 


### PR DESCRIPTION
The placement of this has been a difficult choice for me, so here's a summary of the discussion that occurred on Discord :
- The point of this is to be read before choosing a dev environment.
- It would make sense to put it in the Software Tutorials section, partly because of the section about programming tips.
- However, if put there (probably at the root), the user would probably already have chosen their dev environment, and would either have clicked the appropriate section directly, or skipped the entry altogether. This would make it useless.
- Another solution would have been to put it as the first entry of both the ASM and C sections ; but this doesn't solve the skipping issue mentioned above, and it creates a bad precedent : a duplicated entry.
- Placing the entry in the "Intro" section makes sense, since it gives an overview of both the GB's capabilities, and dev environments. It would also be one of the first things people would land on, which would help it drive its point home (it is intended to provide insights on which environments to choose, as well as community entry points).